### PR TITLE
feat: added more data of songs and fix stuff

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,28 @@
 import EventEmitter from "events";
 export { version } from './package.json';
 
-interface SongUpdateData {
-  songName: string;
-  songArtist: string;
-  songRequest: string;
-  songAlbum: string;
-  songCover: string;
+export interface SongUpdateArtistData {
+  id: number;
+  name: string;
+  nameRomaji: string;
+  image: string;
+}
+
+export interface SongUpdateAlbumData {
+  id: number;
+  name: string;
+  nameRomaji: string;
+  image: string;
+}
+
+export interface SongUpdateData {
+  id: number;
+  name: string;
+  artists: SongUpdateArtistData[];
+  requester: string;
+  albums: SongUpdateAlbumData[];
+  cover: string;
+  duration: number;
   listeners: number;
 }
 

--- a/src/ws/Events.js
+++ b/src/ws/Events.js
@@ -26,6 +26,8 @@ class Events {
     static message(string) {
         try {
             const msg = JSON.parse(string);
+            const defaultImage = 'https://listen.moe/images/share.jpg';
+
             switch (msg.op) {
                 case 0: {
                     this.attempts = 0;
@@ -40,14 +42,13 @@ class Events {
                     const { d } = msg;
                     if (!d.song) break;
                     this.data = {
-                        songId: d.song.id || 0,
-                        songName: d.song.title ? d.song.title : 'None',
-                        songArtist: d.song.artists.length ? d.song.artists.map(a => a.nameRomaji || a.name).join(', ') : 'None',
-                        songArtistId: d.song.artists.length > 0 ? d.song.artists[0].id || 0 : 0,
-                        songRequest: d.requester ? d.requester.displayName : 'None',
-                        songAlbum: d.song.albums && d.song.albums.length > 0 ? d.song.albums[0].name : 'None',
-                        songCover: d.song.albums && d.song.albums.length > 0 && d.song.albums[0].image ? `https://cdn.listen.moe/covers/${d.song.albums[0].image}` : 'https://listen.moe/images/share.jpg',
-                        songDuration: d.song.duration || 0,
+                        id: d.song.id || 0,
+                        name: d.song.title || 'none',
+                        artists: d.song.artists ? d.song.artists.map((a) => ({ ...a, image: a.image ? `https://cdn.listen.moe/artist/${a.image}` : defaultImage })) : [],
+                        requester: d.requester ? d.requester.displayName : 'none',
+                        albums: d.song.albums ? d.song.albums.map((a) => ({ ...a, image: a.image ? `https://cdn.listen.moe/albums/${a.image}` : defaultImage })) : [],
+                        cover: d.song.albums && d.song.albums.length > 0 && d.song.albums[0].image ? `https://cdn.listen.moe/covers/${d.song.albums[0].image}` : defaultImage,
+                        duration: d.song.duration || 0,
                         listeners: d.listeners || 0
                     };
                     this.harusame.emit('songUpdate', this.name, this.data);


### PR DESCRIPTION
1. `feat(Types):` fixed minor type problems
2. `feat(Socket):` added more data of songs
3. `fix(Socket):` broken album default url
4. `feat(Socket):` improved song data structure

I changed the structure of the songs because the property names were redundant and made the album and artist fields return the original array given by listen.moe, to have a better flow of song data.